### PR TITLE
[refactor] ステージデータ構造の再開発

### DIFF
--- a/Assets/DataObjects/StageData.asset
+++ b/Assets/DataObjects/StageData.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6528600bdb197d882564ddab7a8270de5f2811d171478f5a5ec50080ded63d0a
-size 760
+oid sha256:42c9232202f1c961587fef8cd658bee674cc221ae4dee7edffa813a2b7f72d0b
+size 1318

--- a/Assets/Scenes/CreatePhase.unity
+++ b/Assets/Scenes/CreatePhase.unity
@@ -1608,6 +1608,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Camera
       objectReference: {fileID: 0}
+    - target: {fileID: 1400435780392463179, guid: e4d852e93b0812b43a16cb9ed92aae64, type: 3}
+      propertyPath: _mazeController
+      value: 
+      objectReference: {fileID: 321828198}
     - target: {fileID: 8712117627589467015, guid: e4d852e93b0812b43a16cb9ed92aae64, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0

--- a/Assets/Scenes/CreatePhase.unity
+++ b/Assets/Scenes/CreatePhase.unity
@@ -777,12 +777,8 @@ MonoBehaviour:
   - {fileID: -549976925186524320, guid: 5d9caeed219cd314d87f1df094afd075, type: 3}
   - {fileID: -549976925186524320, guid: 5d9caeed219cd314d87f1df094afd075, type: 3}
   - {fileID: -549976925186524320, guid: 5d9caeed219cd314d87f1df094afd075, type: 3}
-  - {fileID: -549976925186524320, guid: 5d9caeed219cd314d87f1df094afd075, type: 3}
-  - {fileID: -549976925186524320, guid: 5d9caeed219cd314d87f1df094afd075, type: 3}
-  - {fileID: -549976925186524320, guid: 5d9caeed219cd314d87f1df094afd075, type: 3}
   defaultSkills: []
-  defaultTurrets:
-  - {fileID: 6233832138599324131, guid: 0281779c11152dd4aa702fee6ae87692, type: 3}
+  defaultTurrets: []
 --- !u!1 &637451205
 GameObject:
   m_ObjectHideFlags: 0
@@ -967,8 +963,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 26d6e4fa171fd8949b521a25477b62d6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  turretPrefab: {fileID: 6233832138599324131, guid: 0281779c11152dd4aa702fee6ae87692, type: 3}
-  mazeCreationController: {fileID: 321828198}
+  turretPrefab: {fileID: 0}
+  mazeCreationController: {fileID: 0}
 --- !u!114 &688432146
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/InvasionPhase.unity
+++ b/Assets/Scenes/InvasionPhase.unity
@@ -181,6 +181,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Camera
       objectReference: {fileID: 0}
+    - target: {fileID: 1400435780392463179, guid: e4d852e93b0812b43a16cb9ed92aae64, type: 3}
+      propertyPath: _mazeController
+      value: 
+      objectReference: {fileID: 998101140}
     - target: {fileID: 8712117627589467015, guid: e4d852e93b0812b43a16cb9ed92aae64, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0

--- a/Assets/Scripts/AClass/AMazeController.cs
+++ b/Assets/Scripts/AClass/AMazeController.cs
@@ -13,8 +13,8 @@ namespace AClass
     public abstract class AMazeController : MonoBehaviour
     {
         /** 各迷路の行列数等の情報格納するスクリプタブルオブジェクト */
-        [FormerlySerializedAs("stageData")] [Header("迷路データ")] [SerializeField]
-        private StageObject stageObject;
+        [Header("迷路データ")] [SerializeField]
+        private  StageObject stageObject;
 
         /** 汎用情報 */
         [FormerlySerializedAs("GeneralS2SData")] [SerializeField]
@@ -23,24 +23,33 @@ namespace AClass
         /** 迷路タイル配列 */
         protected ATile[][] Maze { get; set; }
 
-
         /**
-     * 全体を同期する
-     */
+         * 全体を同期する
+         */
         protected abstract void Sync();
 
+        // TODO: 進捗と選択状況からステージデータをとる。いったんノーマルを取っておく
+        [NonSerialized] public StageData StageData;
         public int Level => generalS2SData.Level;
         public int Stage => generalS2SData.Stage;
-        public int MazeRows => stageObject.GetMazeRows(0);
-        public int MazeColumns => stageObject.GetMazeColumns(0);
-        public TilePosition StartPosition => stageObject.GetStartPosition(0);
-        public TilePosition GoalPosition => stageObject.GetGoalPosition(0);
-        public int ReRollWaitTime => stageObject.GetReRollWaitTime(0);
-        public int TrapCount => stageObject.GetTrapCount(0);
+        public int MazeRows => StageData.mazeRow;
+        public int MazeColumns => StageData.mazeColumn;
+        public TilePosition StartPosition => StageData.start;
+        public TilePosition GoalPosition => StageData.goal;
+        public int ReRollWaitTime => StageData.reRollWaitTime;
+        public int TrapCount => StageData.trapCount;
+        
+        void Awake()
+        {
+            // セーブデータからステージデータをとる
+            StageData = 
+                SaveController.GetStageData(stageObject) 
+                ?? stageObject.getNormalStageData();
+        }
 
         /**
-     * ベースの迷路配列と指定配列を同期する
-     */
+         * ベースの迷路配列と指定配列を同期する
+         */
         protected void SyncMazeData(ATile[][] maze)
         {
             Maze = new ATile[maze.Length][];
@@ -67,9 +76,9 @@ namespace AClass
         }
 
         /**
-     * 現在の迷路での指定地点間の最短経路を出す
-     * ないときはnull
-     */
+         * 現在の迷路での指定地点間の最短経路を出す
+         * ないときはnull
+         */
         [CanBeNull]
         public Path GetShortestPath(TilePosition start, TilePosition destination)
         {

--- a/Assets/Scripts/AClass/AMazeController.cs
+++ b/Assets/Scripts/AClass/AMazeController.cs
@@ -37,7 +37,16 @@ namespace AClass
         public TilePosition StartPosition => StageData.start;
         public TilePosition GoalPosition => StageData.goal;
         public int ReRollWaitTime => StageData.reRollWaitTime;
-        public int TrapCount => StageData.trapCount;
+
+        public int TrapCount
+        {
+            get => _placedTrapCount == -1 
+                    ? StageData.trapCount 
+                    : _placedTrapCount;
+            set => _placedTrapCount = value;
+        }
+        
+        private int _placedTrapCount = -1;
         
         void Awake()
         {

--- a/Assets/Scripts/CreatePhase/CreationSceneController.cs
+++ b/Assets/Scripts/CreatePhase/CreationSceneController.cs
@@ -29,6 +29,7 @@ namespace CreatePhase
         {
             // セーブデータを保存
             SaveController.SavePhase(Phase.Create);
+            SaveController.SaveStageData(mazeCreationController.StageData);
             SaveController.SaveTileData(mazeCreationController.GetTileData());
             SaveController.SaveTrapData(mazeCreationController.TrapData);
         }
@@ -42,6 +43,7 @@ namespace CreatePhase
             var shortestPath = mazeCreationController.GetShortestS2GPath();
             if (shortestPath == null)
             {
+                // TODO: 迷路が不通のダイアログを出す。
                 Debug.Log("迷路がつながってないよ");
                 return;
             }

--- a/Assets/Scripts/CreatePhase/MazeCreationController.cs
+++ b/Assets/Scripts/CreatePhase/MazeCreationController.cs
@@ -96,9 +96,9 @@ namespace CreatePhase
         }
 
         /**
-     * 迷路の生成
-     * すべてのタイルを生成し、初期化する
-     */
+         * 迷路の生成
+         * すべてのタイルを生成し、初期化する
+         */
         private void CreateMaze([CanBeNull] TileData[][] tileData, [CanBeNull] TrapData[] trapData = null)
         {
             // 原点を設定

--- a/Assets/Scripts/DataClass/LevelData.cs
+++ b/Assets/Scripts/DataClass/LevelData.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DataClass
+{
+    /**
+     * ノーマル・エリート・ボス等の大枠データ
+     * それに属するステージデータと報酬データを持つ
+     */
+    [Serializable]
+    public class LevelData
+    {
+        // ReSharper disable once InconsistentNaming
+        public List<StageData> StageDataList = new List<StageData>();
+        
+        public List<RewardData> RewardDataList = new List<RewardData>();
+    }
+}

--- a/Assets/Scripts/DataClass/LevelData.cs.meta
+++ b/Assets/Scripts/DataClass/LevelData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a3371ddc2752469cb8a6e3d443d699fa
+timeCreated: 1726980559

--- a/Assets/Scripts/DataClass/RewardData.cs
+++ b/Assets/Scripts/DataClass/RewardData.cs
@@ -1,0 +1,10 @@
+﻿namespace DataClass
+{
+    /**
+     *  報酬情報のデータクラス
+     */
+    public class RewardData
+    {
+        
+    }
+}

--- a/Assets/Scripts/DataClass/RewardData.cs.meta
+++ b/Assets/Scripts/DataClass/RewardData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2511e0bdbeea41faaffa9f2d29dd7c78
+timeCreated: 1726980636

--- a/Assets/Scripts/DataClass/StageData.cs
+++ b/Assets/Scripts/DataClass/StageData.cs
@@ -1,51 +1,87 @@
-using System;
-using UnityEngine;
-using UnityEngine.Serialization;
-using Debug = System.Diagnostics.Debug;
+﻿using System;
+using Enums;
 
 namespace DataClass
 {
-    [Serializable]
-    public class StageData
-    {
-        /**
-         * 迷路の行数
-         */
-        public int mazeRow;
+ [Serializable]
+ public class StageData
+ {
+  /**
+   * 迷路の行数
+   */
+  public int mazeRow;
 
-        /**
-         * 迷路の列数
-         */
-        public int mazeColumn;
+  /**
+   * 迷路の列数
+   */
+  public int mazeColumn;
 
-        /**
-         * トラップの設置数
-         */
-        public int trapCount;
+  /**
+   * トラップの設置数
+   */
+  public int trapCount;
 
-        /**
-         * リロール待機時間
-         */
-        public int reRollWaitTime;
+  /**
+   * リロール待機時間
+   */
+  public int reRollWaitTime;
 
-        /**
-         * ステージの時間
-         */
-        public int stageTime;
+  /**
+   * ステージの時間
+   */
+  public int stageTime;
 
-        /**
-         * スタートの列
-         */
-        public TilePosition start;
+  /**
+   * スタートの列
+   */
+  public TilePosition start;
 
-        /**
-         * ゴールの列
-         */
-        public TilePosition goal;
+  /**
+   * ゴールの列
+   */
+  public TilePosition goal;
 
-        /**
-         * 侵攻データ
-         */
-        public InvasionData invasionData = new InvasionData();
-    }
+  /**
+   * 侵攻データ
+   */
+  public InvasionData invasionData;
+
+  /**
+   * ステージデータの識別名
+   * セーブロードでの情報取得に利用
+   */
+  public string stageName;
+
+  /**
+   * ノーマル・エリート・ボスのどれか
+   */
+  public StageType StageType
+  {
+   set
+   {
+    // ステージタイプが未定義の場合のみ変更可能
+    if (_stageType != StageType.Undefined)
+     throw new Exception("ステージタイプは変更できません");
+
+    _stageType = value;
+   }
+   get => _stageType;
+  }
+
+  [NonSerialized] private StageType _stageType = StageType.Undefined;
+  
+  public StageData(StageData stageData)
+  {
+   mazeRow = stageData.mazeRow;
+   mazeColumn = stageData.mazeColumn;
+   trapCount = stageData.trapCount;
+   reRollWaitTime = stageData.reRollWaitTime;
+   stageTime = stageData.stageTime;
+   start = stageData.start;
+   goal = stageData.goal;
+   invasionData = stageData.invasionData;
+   StageType = stageData.StageType;
+   stageName = stageData.stageName;
+  }
+ }
 }

--- a/Assets/Scripts/DataClass/StageData.cs.meta
+++ b/Assets/Scripts/DataClass/StageData.cs.meta
@@ -1,3 +1,0 @@
-fileFormatVersion: 2
-guid: ea2c928101314ba1abfd5f8be2146386
-timeCreated: 1722847189

--- a/Assets/Scripts/DataClass/TurretData.cs.meta
+++ b/Assets/Scripts/DataClass/TurretData.cs.meta
@@ -1,3 +1,3 @@
 ﻿fileFormatVersion: 2
-guid: f437531eca424dd7a4f4f18354a1b1c8
-timeCreated: 1726151022
+guid: 0ac6d6be98214a2888b83e356542308e
+timeCreated: 1727071656

--- a/Assets/Scripts/DataClass/stageData.cs.meta
+++ b/Assets/Scripts/DataClass/stageData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f834643b99ff41a58289b6ea5bb9d0e2
+timeCreated: 1726988377

--- a/Assets/Scripts/Enums/StageType.cs
+++ b/Assets/Scripts/Enums/StageType.cs
@@ -1,0 +1,12 @@
+﻿using Unity.VisualScripting;
+
+namespace Enums
+{
+    public enum StageType
+    {
+        Undefined,
+        Normal,
+        Elite,
+        Boss
+    }
+}

--- a/Assets/Scripts/Enums/StageType.cs.meta
+++ b/Assets/Scripts/Enums/StageType.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e0294851179f486c9781b1932c7d5e46
+timeCreated: 1726990433

--- a/Assets/Scripts/InvasionPhase/InvasionController.cs
+++ b/Assets/Scripts/InvasionPhase/InvasionController.cs
@@ -113,6 +113,8 @@ namespace InvasionPhase
 
             Debug.Log("Game Clear!");
             GameState = GameState.Clear;
+
+            // 報酬付与
         }
 
         public void FastPlay()

--- a/Assets/Scripts/InvasionPhase/InvasionController.cs
+++ b/Assets/Scripts/InvasionPhase/InvasionController.cs
@@ -81,6 +81,7 @@ namespace InvasionPhase
             // シーン遷移で読み込んだデータをそのまま保存
             SaveController.SaveTileData(mazeController.TileData);
             SaveController.SaveTrapData(mazeController.TrapData);
+            SaveController.SaveStageData(mazeController.StageData);
         }
 
 

--- a/Assets/Scripts/InvasionPhase/InvasionEnemyController.cs
+++ b/Assets/Scripts/InvasionPhase/InvasionEnemyController.cs
@@ -45,7 +45,7 @@ namespace InvasionPhase
         public void Start()
         {
             // ステージデータを取得
-            _currentStageData = stageObject.GetStageData(0);
+            _currentStageData = invasionMazeController.StageData;
 
             // 残りの敵数を設定
             _remainingEnemyCount = _currentStageData.invasionData.GetEnemyCount();

--- a/Assets/Scripts/MainCamera.cs
+++ b/Assets/Scripts/MainCamera.cs
@@ -1,4 +1,6 @@
+using AClass;
 using CreatePhase;
+using DataClass;
 using ScriptableObjects;
 using ScriptableObjects.S2SDataObjects;
 using UnityEngine;
@@ -24,18 +26,19 @@ public class MainCamera : MonoBehaviour
     /** マウスの縦制限 */
     private float _mouseZLimit;
 
-    /** ステージデータ */
-    [FormerlySerializedAs("_stageData")] [SerializeField]
-    private StageObject stageObject;
+    /** 迷路情報 */
+    [SerializeField] private AMazeController _mazeController;
 
     /** 一般情報 */
     [SerializeField] private GeneralS2SData _generalS2SData;
+    
+    private StageData _stageData => _mazeController.StageData;
 
     // Start is called before the first frame update
     void Start()
     {
-        _mouseXLimit = stageObject.GetMazeColumns(0) * 0.5f;
-        _mouseZLimit = stageObject.GetMazeRows(0) * 0.5f;
+        _mouseXLimit = _stageData.mazeColumn * 0.5f;
+        _mouseZLimit = _stageData.mazeRow * 0.5f;
     }
 
     // Update is called once per frame

--- a/Assets/Scripts/SaveController.cs
+++ b/Assets/Scripts/SaveController.cs
@@ -1,6 +1,7 @@
 using DataClass;
 using Enums;
 using JetBrains.Annotations;
+using ScriptableObjects;
 using UnityEngine;
 
 public static class SaveController
@@ -51,6 +52,11 @@ public static class SaveController
 
         PlayerPrefs.SetString("TrapData", saveText);
     }
+    
+    public static void SaveStageData(StageData stageData)
+    {
+        PlayerPrefs.SetString("StageName", stageData.stageName);
+    }
 
     // =======　読み込み処理　=======
     [CanBeNull]
@@ -86,14 +92,6 @@ public static class SaveController
         return (Phase)PlayerPrefs.GetInt("Phase", 0);
     }
 
-    /**
-     * セーブデータを削除する
-     */
-    public static void DelSave()
-    {
-        PlayerPrefs.DeleteAll();
-    }
-
     public static TrapData[] LoadTrapData()
     {
         if (!PlayerPrefs.HasKey("TrapData")) return null;
@@ -110,5 +108,24 @@ public static class SaveController
         }
 
         return trapData;
+    }
+
+    [CanBeNull]
+    public static StageData GetStageData(StageObject stageObject)
+    {
+        // セーブデータがない場合はnullを返す
+        var stageName = PlayerPrefs.GetString("StageName", null);
+        if (stageName == "") return null;
+
+        var result = stageObject.GetFromStageName(stageName);
+        return result;
+    }
+
+    /**
+     * セーブデータを削除する
+     */
+    public static void DelSave()
+    {
+        PlayerPrefs.DeleteAll();
     }
 }

--- a/Assets/Scripts/ScriptableObjects/DefaultValueObject.cs
+++ b/Assets/Scripts/ScriptableObjects/DefaultValueObject.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace ScriptableObjects
+{
+    public class DefaultValueObject : ScriptableObject
+    {
+        [SerializeField] public int defaultWallet { get; private set; }
+    }
+}

--- a/Assets/Scripts/ScriptableObjects/DefaultValueObject.cs.meta
+++ b/Assets/Scripts/ScriptableObjects/DefaultValueObject.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2cf7943bb20a43a1a8e7c0e48025efd1
+timeCreated: 1726861653

--- a/Assets/Scripts/ScriptableObjects/StageObject.cs
+++ b/Assets/Scripts/ScriptableObjects/StageObject.cs
@@ -1,77 +1,95 @@
 using System;
 using System.Collections.Generic;
 using DataClass;
+using JetBrains.Annotations;
 using UnityEngine;
 
 namespace ScriptableObjects
 {
+    /**
+     * ステージデータのScriptableObject
+     * ステージデータを保持するラッパーオブジェクト
+     */
     // ReSharper disable InconsistentNaming
     [CreateAssetMenu]
     public class StageObject : ScriptableObject
     {
-        [SerializeField] List<StageData> stageDataList = new List<StageData>();
-
+        [SerializeField] private LevelData normalLevelData;
+        [SerializeField] private LevelData eliteLevelData;
+        [SerializeField] private LevelData bossLevelData;
+        
+        
         /**
-         * リロール待機時間を取得する
+         * ノーマルステージデータを取得
+         * 引数がない場合はランダムで取得
          */
-        public int GetReRollWaitTime(int stageNum)
+        public StageData getNormalStageData(int stageNum = -1)
         {
-            // 指定ステージ、レベルのリロール待機時間を取得
-            return GetStageData(stageNum).reRollWaitTime;
-        }
-
-        /**
-         * 迷路の行数を取得する
-         */
-        public int GetMazeRows(int stageNum)
-        {
-            // 指定ステージ、レベルの迷路の行数を取得
-            return GetStageData(stageNum).mazeRow;
-        }
-
-        /**
-         * 迷路の列数を取得する
-         */
-        public int GetMazeColumns(int stageNum)
-        {
-            // 指定ステージ、レベルの迷路の列数を取得
-            return GetStageData(stageNum).mazeColumn;
+            if (stageNum == -1)
+            {
+                // ステージナンバーが未指定の時はランダムで取得
+                stageNum = UnityEngine.Random.Range(0, normalLevelData.StageDataList.Count);
+            }
+            
+            // ステージタイプをノーマルに変更
+            var result = new StageData(normalLevelData.StageDataList[stageNum]);
+            result.StageType = Enums.StageType.Normal;
+            
+            return result;
         }
 
         /**
-         * トラップの設置数を取得する
+         * エリートステージデータを取得
+         * 引数がない場合はランダムで取得
          */
-        public int GetTrapCount(int stageNum)
+        public StageData getEliteStageData(int stageNum = -1)
         {
-            // 指定ステージ、レベルのトラップの設置数を取得
-            return GetStageData(stageNum).trapCount;
+            if (stageNum == -1)
+            {
+                // ステージナンバーが未指定の時はランダムで取得
+                stageNum = UnityEngine.Random.Range(0, eliteLevelData.StageDataList.Count);
+            }
+            
+            // ステージタイプをエリートに変更
+            var result = eliteLevelData.StageDataList[stageNum];
+            result.StageType = Enums.StageType.Elite;
+            
+            return result;
         }
 
         /**
-         * スタート位置を取得する
+         * ボスステージデータを取得
+         * 引数がない場合はランダムで取得
          */
-        public TilePosition GetStartPosition(int stageNum)
+        public StageData getBossStageData(int stageNum = -1)
         {
-            // 指定ステージ、レベルのスタート位置を取得
-            return GetStageData(stageNum).start;
+            if (stageNum == -1)
+            {
+                // ステージナンバーが未指定の時はランダムで取得
+                stageNum = UnityEngine.Random.Range(0, bossLevelData.StageDataList.Count);
+            }
+            
+            // ステージタイプをボスに変更
+            var result = bossLevelData.StageDataList[stageNum];
+            result.StageType = Enums.StageType.Boss;
+            
+            return result;
         }
 
         /**
-         * ゴール位置を取得する
+         * ステージ名からステージデータを取得
          */
-        public TilePosition GetGoalPosition(int stageNum)
+        [CanBeNull]
+        public StageData GetFromStageName(string stageName)
         {
-            // 指定ステージ、レベルのゴール位置を取得
-            return GetStageData(stageNum).goal;
-        }
-
-        public List<StageData> GetStageDataList()
-        {
-            return stageDataList;
-        }
-        public StageData GetStageData(int i)
-        {
-            return stageDataList[i];
+            var allStageData = new List<StageData>();
+            allStageData.AddRange(normalLevelData.StageDataList);
+            allStageData.AddRange(eliteLevelData.StageDataList);
+            allStageData.AddRange(bossLevelData.StageDataList);
+            
+           var result = allStageData.Find(stageData => stageData.stageName == stageName);
+           
+           return result;
         }
     }
 }

--- a/Assets/Scripts/WalletController.cs
+++ b/Assets/Scripts/WalletController.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using ScriptableObjects;
+using UnityEngine;
+
+public class WalletController : MonoBehaviour
+{
+    [SerializeField] private DefaultValueObject defaultValueObject;
+
+    private int wallet;
+
+    public void Start()
+    {
+        wallet = defaultValueObject.defaultWallet;
+    }
+}

--- a/Assets/Scripts/WalletController.cs.meta
+++ b/Assets/Scripts/WalletController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4167939399452c8409ff4905aff54a4b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UI Toolkit.meta
+++ b/Assets/UI Toolkit.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 112511663deed7b4085402b30018f087
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UI Toolkit/PanelSettings.asset
+++ b/Assets/UI Toolkit/PanelSettings.asset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d596c8513812af5de4f024894fa1aa3ccbb8b05b8b7e3834a15fa5c4ac5cd702
+size 1250

--- a/Assets/UI Toolkit/PanelSettings.asset.meta
+++ b/Assets/UI Toolkit/PanelSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4c09fda9176224e49843be68651173a3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UI Toolkit/UnityThemes.meta
+++ b/Assets/UI Toolkit/UnityThemes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 69bb35fe29b50e043af67883aca79f2b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UI Toolkit/UnityThemes/UnityDefaultRuntimeTheme.tss
+++ b/Assets/UI Toolkit/UnityThemes/UnityDefaultRuntimeTheme.tss
@@ -1,0 +1,1 @@
+@import url("unity-theme://default");

--- a/Assets/UI Toolkit/UnityThemes/UnityDefaultRuntimeTheme.tss.meta
+++ b/Assets/UI Toolkit/UnityThemes/UnityDefaultRuntimeTheme.tss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c57fd2ed07f90f6489935941e9b43802
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12388, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0


### PR DESCRIPTION
### 対応内容
- 報酬追加に伴い、ステージデータを格納していたscriptableObjectをリファクタリングしました
- Nomal・Elite・Bossの種類ごとにステージデータを登録するように。
  - 今後はそれぞれのタイプごとに報酬を指定することを考えています。
- セーブ用にステージデータにステージ名を振るようにしました。
  - 重複があった場合もエラーを吐くことはありませんが、エラーを吐く可能性があるので気をつけてください。
- 現在は開始時にセーブデータがなければランダムでノーマルステージを読み込むようになっています。
### テスト内容
- セーブロード・迷路制作・侵攻シーンへの移動等を行いバグがないか確認お願いします