### PR TITLE
[fix] デッキのセーブデータ読み込み不良修正

### DIFF
--- a/Assets/Scripts/SaveController.cs
+++ b/Assets/Scripts/SaveController.cs
@@ -125,33 +125,39 @@ public static class SaveController
         
         // トラップ山札
         var deckTrapsText = "";
-        foreach (var trap in deckTraps) deckTrapsText += $"{trap},";
+        foreach (var trap in deckTraps) deckTrapsText += $"{trap.GetTrapName()},";
         if (deckTrapsText.Length != 0)
             deckTrapsText = deckTrapsText.Substring(0, deckTrapsText.Length - 1);
         saveText += deckTrapsText + "\n";
         
         // トラップ手札
         var handTrapsText = "";
-        foreach (var trap in handTraps) handTrapsText += $"{trap},";
+        foreach (var trap in handTraps) handTrapsText += $"{trap.GetTrapName()},";
         if (handTrapsText.Length != 0)
             handTrapsText = handTrapsText.Substring(0, handTrapsText.Length - 1);
         saveText += handTrapsText + "\n";
         
         // トラップ捨て場
         var discardTrapsText = "";
-        foreach (var trap in discardTraps) discardTrapsText += $"{trap},";
+        foreach (var trap in discardTraps) discardTrapsText += $"{trap.GetTrapName()},";
         if (discardTrapsText.Length != 0)
             discardTrapsText = discardTrapsText.Substring(0, discardTrapsText.Length - 1);
         saveText += discardTrapsText + "\n";
         
         // スキル
         var skillsText = "";
-        foreach (var skill in aSkills) skillsText += $"{skill},";
+        foreach (var skill in aSkills) skillsText += $"{skill.GetSkillName()},";
         if (skillsText.Length != 0)
             skillsText = skillsText.Substring(0, skillsText.Length - 1);
         saveText += skillsText + "\n";
         
-        
+        // タレット
+        var turretsText = "";
+        foreach (var turret in aTurrets) turretsText += $"{turret.GetTurretName()},";
+        if (turretsText.Length != 0)
+            turretsText = turretsText.Substring(0, turretsText.Length - 1);
+        saveText += turretsText;
+
         PlayerPrefs.SetString("DeckData", saveText);
     }
     
@@ -343,7 +349,7 @@ public static class SaveController
         // セーブデータを読み込んで消す
         var saveText = PlayerPrefs.GetString("DeckData");
         PlayerPrefs.DeleteKey("DeckData");
-        
+
         if (saveText == "") return null;
         
         // セーブデータを行ごとに分ける

--- a/Assets/Scripts/lib/InstanceGenerator.cs
+++ b/Assets/Scripts/lib/InstanceGenerator.cs
@@ -20,8 +20,8 @@ namespace lib
             foreach (var trap in traps)
                 if (trap.GetTrapName() == trapName)
                     return trap;
-
-            throw new Exception("トラップデータが見つかりません、セーブデータが壊れている可能性があります。");
+            
+            throw new Exception("トラップデータが見つかりません、セーブデータが壊れている可能性があります。 " + trapName);
         }
 
         /**
@@ -29,6 +29,8 @@ namespace lib
          */
         public static ATurret GenerateTurret(string turretName)
         {
+            if (turretName == "") return null;
+            
             var turrets = Resources.LoadAll<ATurret>("Prefabs/Turrets");
 
             // Linqを使うと見づらいのでforeachで書いている
@@ -42,6 +44,8 @@ namespace lib
 
         public static ASkill GenerateSkill(string skill)
         {
+            if (skill == "") return null;
+            
             var skills = Resources.LoadAll<ASkill>("Prefabs/Skill");
 
             // Linqを使うと見づらいのでforeachで書いている

--- a/Assets/Shader/Failed.mat
+++ b/Assets/Shader/Failed.mat
@@ -16,7 +16,7 @@ Material:
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 2500
+  m_CustomRenderQueue: 2050
   stringTagMap: {}
   disabledShaderPasses: []
   m_LockedProperties: 


### PR DESCRIPTION
### 対応内容
- セーブ用テキスト作成アルゴリズムがバグってたので修正しました
### テスト内容
- 正常にロードでき前回プレイ時のデッキデータが再現されること