### PR TITLE
[fix] 屋台に寄せられた敵がエラーを吐く問題を修正

### DIFF
--- a/Assets/Prefabs/Enemies/DefaultEnemy.prefab
+++ b/Assets/Prefabs/Enemies/DefaultEnemy.prefab
@@ -941,7 +941,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   generalS2SData: {fileID: 11400000, guid: 13c6bbfa80854634893e1fb6d49eaea5, type: 2}
-  teleportPrefab: {fileID: 5820428196558648048, guid: d6b2c3f501547014bb441311b9b6c9c5, type: 3}
+  teleportPrefab: {fileID: 2685570924336315078, guid: 3f18bf6984f05f74c86f104a7120f3ad, type: 3}
   animator: {fileID: 967619587107861040}
   textMeshProGeometryAnimator: {fileID: 3446555257024738834}
   damageText: {fileID: 418558301846419984}

--- a/Assets/Scripts/AClass/AEnemy.cs
+++ b/Assets/Scripts/AClass/AEnemy.cs
@@ -248,6 +248,9 @@ namespace AClass
 
             // 移動中のアニメーションを再生
             PlayMoveAnimation();
+            
+            // 目的地と現在地が同じ場合は何もしない
+            if (CurrentPosition.Equals(Destination)) return;
 
             // 経路がない場合は生成
             if (Path == null)

--- a/Assets/Scripts/AClass/AMazeController.cs
+++ b/Assets/Scripts/AClass/AMazeController.cs
@@ -133,8 +133,11 @@ namespace AClass
          * ないときはnull
          */
         [CanBeNull]
-        public Path GetShortestPath(TilePosition start, TilePosition destination, bool considerBlockTile = false)
-        {
+        public Path GetShortestPath(
+            TilePosition start,
+            TilePosition destination,
+            bool considerBlockTile = false
+        ) {
             Sync();
 
             // 検索中のパスを保持するリスト

--- a/Assets/Shader/Failed.mat
+++ b/Assets/Shader/Failed.mat
@@ -16,7 +16,7 @@ Material:
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 2050
+  m_CustomRenderQueue: 2500
   stringTagMap: {}
   disabledShaderPasses: []
   m_LockedProperties: 


### PR DESCRIPTION
### 対応内容
- 屋台に引き寄せられた敵がとどまる動作をする場合にエラーが発生するため、同一の目的地の時は移動しないように修正
### テスト内容
- 屋台の効果時間中に屋台の隣接マスで留まるように設置して、留まるときにエラーが発生しないかどうか確認お願いします
- @Ringoameman 俺が確認できたバグは修正できたけどそっちで発生させた感じで試してうまく動くか確認お願いします。